### PR TITLE
chore: upgrade TypeScript to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rslib",
     "dev": "rslib -w",
@@ -45,7 +47,7 @@
     "nano-staged": "^0.9.0",
     "playwright": "^1.57.0",
     "simple-git-hooks": "^2.13.1",
-    "typescript": "^5.9.3"
+    "typescript": "6.0.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "^1.0.0 || ^2.0.0-0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 2.0.0-beta.6(core-js@3.47.0)
       '@rslib/core':
         specifier: ^0.18.2
-        version: 0.18.2(typescript@5.9.3)
+        version: 0.18.2(typescript@6.0.2)
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
@@ -40,8 +40,8 @@ importers:
         specifier: ^2.13.1
         version: 2.13.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: 6.0.2
+        version: 6.0.2
 
 packages:
 
@@ -564,8 +564,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -781,12 +781,12 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.18.2(typescript@5.9.3)':
+  '@rslib/core@0.18.2(typescript@6.0.2)':
     dependencies:
       '@rsbuild/core': 1.6.10
-      rsbuild-plugin-dts: 0.18.2(@rsbuild/core@1.6.10)(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.18.2(@rsbuild/core@1.6.10)(typescript@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@typescript/native-preview'
 
@@ -992,12 +992,12 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  rsbuild-plugin-dts@0.18.2(@rsbuild/core@1.6.10)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.18.2(@rsbuild/core@1.6.10)(typescript@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.6.10
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   sax@1.5.0: {}
 
@@ -1017,6 +1017,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.16.0: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,15 @@
 {
   "compilerOptions": {
+    "rootDir": "./src",
     "outDir": "./dist",
-    "baseUrl": "./",
-    "target": "ES2020",
+    "target": "ES2023",
+    "types": ["node"],
     "lib": ["DOM", "ESNext"],
-    "module": "Node16",
-    "strict": true,
     "declaration": true,
     "isolatedModules": true,
-    "esModuleInterop": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "moduleResolution": "Node16"
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- Upgrade TypeScript to 6.0.2.
- Replace the root `tsconfig.json` with the shared NodeNext configuration.
- Validate the change with `pnpm build` and `pnpm test`.

## Related Links

- https://github.com/microsoft/TypeScript/releases/tag/v6.0.2