### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@rsbuild/plugin-image-compress",
   "version": "1.3.4",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-image-compress",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-image-compress#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-image-compress/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add package homepage metadata pointing to the repository README
- add bugs.url metadata pointing to the GitHub issue tracker

## Why
This makes the npm package page expose the project homepage and issue tracker directly.

## Validation
- node metadata assertion for homepage and bugs.url
- npm view @rsbuild/plugin-image-compress@latest name version repository.url homepage bugs --json
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm run lint
- pnpm run build
- pnpm run test
- npm pack --dry-run --ignore-scripts --json .
- git diff --check